### PR TITLE
Fix: Correct here-document syntax in SRT split workflow

### DIFF
--- a/.github/workflows/split-srt.yml
+++ b/.github/workflows/split-srt.yml
@@ -46,7 +46,7 @@ jobs:
               f.write(part1.strip() + '\n')
           with open(part2_file, 'w', encoding='utf-8') as f:
               f.write(part2.strip() + '\n')
-          EOF    
+EOF
 
       - name: Upload split SRT files as artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
The EOF marker in the Python script within the GitHub Actions workflow was indented, causing a parsing error. This commit unindents the EOF marker to ensure the shell correctly interprets the here-document.