### PR TITLE
feat: Add manual SRT processing workflow

### DIFF
--- a/.github/workflows/process-srt-manual.yml
+++ b/.github/workflows/process-srt-manual.yml
@@ -1,0 +1,36 @@
+name: Process SRT Manually
+
+on:
+  workflow_dispatch:
+    inputs:
+      input_srt_path:
+        description: 'Path to the input SRT file (e.g., HUAWEI.srt or subtitles/my_video.srt)'
+        required: true
+        type: string
+      output_srt_filename:
+        description: 'Desired name for the processed output SRT file (e.g., processed_HUAWEI.srt)'
+        required: true
+        type: string
+
+jobs:
+  process_and_upload:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x' # Use a recent Python 3 version
+
+      - name: Run SRT processing script
+        run: |
+          python process_srt.py --input "${{ github.event.inputs.input_srt_path }}" --output "${{ github.event.inputs.output_srt_filename }}"
+        shell: bash
+
+      - name: Upload processed SRT artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: processed-srt-${{ github.event.inputs.output_srt_filename }} # Unique artifact name including output filename
+          path: ${{ github.event.inputs.output_srt_filename }}

--- a/process_srt.py
+++ b/process_srt.py
@@ -1,0 +1,99 @@
+import argparse
+import sys
+
+def parse_srt_block(lines):
+    """Parses a single SRT block."""
+    if not lines:
+        return None
+
+    try:
+        sequence = int(lines[0])
+        timeline = lines[1]
+        text = "\n".join(lines[2:])
+        return {"sequence": sequence, "timeline": timeline, "text": text}
+    except (IndexError, ValueError) as e:
+        # print(f"Warning: Skipping invalid block: {lines} due to {e}", file=sys.stderr)
+        return None
+
+def srt_file_to_blocks(srt_content):
+    """Parses SRT file content into a list of subtitle blocks."""
+    blocks = []
+    current_lines = []
+    for line in srt_content.splitlines():
+        line = line.strip()
+        if line:
+            current_lines.append(line)
+        else:
+            if current_lines:
+                block = parse_srt_block(current_lines)
+                if block:
+                    blocks.append(block)
+                current_lines = []
+
+    if current_lines: # Add the last block if the file doesn't end with a blank line
+        block = parse_srt_block(current_lines)
+        if block:
+            blocks.append(block)
+
+    return blocks
+
+def blocks_to_srt_string(blocks):
+    """Converts a list of subtitle blocks back to SRT string format."""
+    srt_string_parts = []
+    for block in blocks:
+        srt_string_parts.append(str(block["sequence"]))
+        srt_string_parts.append(block["timeline"])
+        srt_string_parts.append(block["text"])
+        srt_string_parts.append("")  # Blank line separator
+    return "\n".join(srt_string_parts)
+
+def create_placeholder_text(original_text):
+    """Creates the placeholder text with the original text embedded."""
+    normalized_original_text = original_text.replace('\r\n', '\n')
+    return f"---BLOCK_START---TRANSLATE_TEXT_BELOW:【{normalized_original_text}】END_OF_TEXT_TO_TRANSLATE. REPLACE_THIS_WHOLE_BLOCK_WITH_TRANSLATION---BLOCK_END---"
+
+def main():
+    parser = argparse.ArgumentParser(description="Process SRT files to create translation placeholders.")
+    parser.add_argument("--input", required=True, help="Path to the input SRT file.")
+    parser.add_argument("--output", required=True, help="Path to the output processed SRT file.")
+
+    args = parser.parse_args()
+
+    try:
+        with open(args.input, "r", encoding="utf-8") as f:
+            srt_content = f.read()
+    except FileNotFoundError:
+        print(f"Error: Input file not found: {args.input}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"Error reading input file {args.input}: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    subtitle_blocks = srt_file_to_blocks(srt_content)
+
+    if not subtitle_blocks:
+        print(f"Warning: No valid subtitle blocks found in {args.input}. Output file will be empty or may not be created as expected.", file=sys.stderr)
+        processed_blocks = []
+    else:
+        processed_blocks = []
+        for block in subtitle_blocks:
+            if block and "text" in block:
+                placeholder = create_placeholder_text(block["text"])
+                processed_blocks.append({
+                    "sequence": block["sequence"],
+                    "timeline": block["timeline"],
+                    "text": placeholder
+                })
+
+    output_srt_string = blocks_to_srt_string(processed_blocks)
+
+    try:
+        with open(args.output, "w", encoding="utf-8") as f:
+            f.write(output_srt_string)
+        print(f"Successfully processed '{args.input}' and saved to '{args.output}'")
+    except Exception as e:
+        print(f"Error writing output file {args.output}: {e}", file=sys.stderr)
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a Python script `process_srt.py` to replace English subtitles with a specified placeholder format.

Also adds a GitHub Actions workflow in
`.github/workflows/process-srt-manual.yml` that allows manual triggering. This workflow takes an input SRT file path and an output filename, processes the SRT file using the script, and uploads the resulting file as a build artifact.

This enables you to process SRT files on demand directly through the GitHub Actions interface.